### PR TITLE
[API] fix double call to db in getting agentId

### DIFF
--- a/src/app/HomePage.js
+++ b/src/app/HomePage.js
@@ -1,29 +1,10 @@
 "use client";
 
 import * as React from "react";
-import Avatar from "@mui/material/Avatar";
-import Button from "@mui/material/Button";
 import CssBaseline from "@mui/material/CssBaseline";
-import TextField from "@mui/material/TextField";
-import FormControlLabel from "@mui/material/FormControlLabel";
-import Checkbox from "@mui/material/Checkbox";
-import Link from "@mui/material/Link";
-import Grid from "@mui/material/Grid";
 import Box from "@mui/material/Box";
-import LockOutlinedIcon from "@mui/icons-material/LockOutlined";
-import Typography from "@mui/material/Typography";
 import Container from "@mui/material/Container";
 import Alert from "@mui/material/Alert";
-import AlertTitle from "@mui/material/AlertTitle";
-import { createTheme, ThemeProvider } from "@mui/material/styles";
-import Table from "@mui/material/Table";
-import TableBody, { tableBodyClasses } from "@mui/material/TableBody";
-import TableCell from "@mui/material/TableCell";
-import TableContainer from "@mui/material/TableContainer";
-import TableHead from "@mui/material/TableHead";
-import TableRow from "@mui/material/TableRow";
-import Stack from "@mui/material/Stack";
-import Paper from "@mui/material/Paper";
 import {
   Autocomplete,
   CircularProgress,
@@ -33,8 +14,6 @@ import {
   Tab,
   Tabs,
 } from "@mui/material";
-import CloudUploadIcon from "@mui/icons-material/CloudUpload";
-import { styled } from "@mui/material/styles";
 import CreateOrExtend from "./UI/CreateOrExtend/CreateOrExtend";
 import ResponsiveAppBar from "./UI/AppBar/AppBar";
 import ExtendUser from "./UI/ExtendUser/ExtendUser";
@@ -68,64 +47,63 @@ function HomePage({ signOut, user }) {
   //User Role = admin | user
   const [userRole, setUserRole] = React.useState("admin");
   const [agentId, setAgentId] = React.useState(null);
+  const [isCreatingAgent, setIsCreatingAgent] = React.useState(false);
 
   //getting current AgentId
   const checkAgentStatus = async () => {
-
     // check if there is already an id
 
-
     const agentId = await getAuthCurrentUser();
-    console.log("AgentId:", agentId);
+    //  console.log("AgentId:", agentId);
     const response = await fetch(`/api/checkAgent?awsId=${agentId}`);
     const data = await response.json();
     console.log("Response: ", data.code);
 
-    if(data.code === 1)
-    {
-      // get the agent id
-      let response = await fetch(`/api/getAgent?awsId=${agentId}`);
-      response = await response.json()
-      setAgentId({id: response.data['AgentID']})
-
-    }
-
-    if (data.code === 0 && !isCreatingAgent) {
-      isCreatingAgent = true;
+    if (data.code === 1) {
+      setAgentId({ id: data.user.AgentID });
+      // console.log('success', agentId);
+    } else if (data.code === 0 && !isCreatingAgent) {
+      setIsCreatingAgent(true); // set the createAgent flag
       setTimeout(async () => {
-        let response = await fetch(`/api/createAgent`, {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({ awsId: agentId }),
-        });
-        response = await response.json()
-        setAgentId({id: response.id})
+        try {
+          let response = await fetch(`/api/createAgent`, {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({ awsId: agentId }),
+          });
+          response = await response.json();
+          setAgentId({ id: response.id });
+        } catch (error) {
+          console.error("Error creating agent:", error);
+        } finally {
+          setIsCreatingAgent(false); // reset the createAgent flag
+        }
       }, 9000);
     }
   };
-  isCreatingAgent = false;
+ 
 
   //Get the page is unable or not
   React.useEffect(() => {
     checkAgentStatus();
 
-    client.graphql({ query: listApps }).then((result) => {
-      let enable = result.data.listApps.items[0].status ? "enable" : "disable";
-      setStatus(enable);
-    });
+  //   client.graphql({ query: listApps }).then((result) => {
+  //     let enable = result.data.listApps.items[0].status ? "enable" : "disable";
+  //     setStatus(enable);
+  //   });
 
-    //always listen for changes in status
-    const updateSub = client
-      .graphql({ query: subscriptions.onUpdateApp })
-      .subscribe({
-        next: ({ data }) => {
-          let enable = data["onUpdateApp"]["status"] ? "enable" : "disable";
-          setStatus(enable);
-        },
-        error: (error) => console.warn(error),
-      });
+  //  // always listen for changes in status
+  //   const updateSub = client
+  //     .graphql({ query: subscriptions.onUpdateApp })
+  //     .subscribe({
+  //       next: ({ data }) => {
+  //         let enable = data["onUpdateApp"]["status"] ? "enable" : "disable";
+  //         setStatus(enable);
+  //       },
+  //       error: (error) => console.warn(error),
+  //     });
   }, []);
 
   //Get user role

--- a/src/app/api/checkAgent/route.js
+++ b/src/app/api/checkAgent/route.js
@@ -3,17 +3,20 @@ import db from "../../utilites/db";
 
 async function checkExistedAgent(awsId) {
   const query = `
-    SELECT EXISTS (
-      SELECT 1
-      FROM Agent
-      WHERE AWSID = ?
-    ) AS AgentExists;
+ SELECT (
+        SELECT 1
+        FROM Agent
+        WHERE AWSID =?
+      ) AS AgentExists,
+      AgentID, AWSID, UserRoleID
+    FROM Agent
+    WHERE AWSID = ?;
   `;
 
-  const values = [awsId];
+  const values = [awsId,awsId];
   try {
     const result = await db(query, values);
-    console.log("Agent exists:", result);
+   // console.log("Agent exists:", result);
     return result; 
   } catch (error) {
     console.error("[DB] Error checking agentDB:", error);
@@ -36,7 +39,7 @@ export async function GET(req) {
     }
 
     const data = await checkExistedAgent(awsId);
-    //console.log("Data:", data); // Log the entire data array
+    console.log("Data from CheckAgent:", data); // Log the entire data array
 
     if (data.length === 0 || data[0].AgentExists === 0) {
       return NextResponse.json(
@@ -44,7 +47,7 @@ export async function GET(req) {
         { status: 404 }
       );
     }
-    return NextResponse.json({ message: "User exists", code: 1 });
+    return NextResponse.json({ message: "User exists", code: 1, user: data[0] });
   } catch (error) {
     console.error("[Error] Cannot load existing agentUser", error);
     return NextResponse.json(


### PR DESCRIPTION
In **checkAgent/route.js**, I modified the SQL query to verify the existence of an agent. If the agent exists, the query retrieves the agent's information, including AgentID, AWSID, and UserRoleID from the relevant database columns. By adjusting the SQL query, obtaining the agent's information in **HomePage.js** now requires only a single API call instead of two. I hope that this change will help prevent overwhelming the database. 
In this PR, I commented and removed the unused snippets and imports.

This is the changed checkAgent[API] response.
![image](https://github.com/user-attachments/assets/d1e770a8-e4f7-4b0f-886c-63364ea6d17f)
